### PR TITLE
feat(Terms of Use): add terms of use to the application

### DIFF
--- a/src/components/SelectionSidebar/SelectionSidebar.js
+++ b/src/components/SelectionSidebar/SelectionSidebar.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import DemoButton from '../DemoButton/DemoButton';
 import PathSelectionOverlay from '../PathSelectionOverlay/PathSelectionOverlay';
 
+const TERMS_OF_USE_URL = 'https://watson-developer-cloud.github.io/terms?name=Watson%20Assistant%20Demo';
 class SelectionSidebar extends React.Component {
   constructor(props) {
     super(props);
@@ -55,6 +56,12 @@ class SelectionSidebar extends React.Component {
             onClick={() => { this.onEnter(); }}
           />
           <p className="ibm-type-a">See all features</p>
+        </div>
+        <div className="path-selection__terms-of-use">
+          By using this application, you agree to the&nbsp;
+          <a target="_blank" rel="noreferrer noopener" href={TERMS_OF_USE_URL}>
+                Terms of Use
+          </a>
         </div>
         <PathSelectionOverlay
           isOverlayVisible={this.state.isOverlayVisible}

--- a/src/components/SelectionSidebar/SelectionSidebar.scss
+++ b/src/components/SelectionSidebar/SelectionSidebar.scss
@@ -45,5 +45,12 @@
         background: $duo-blue-60;
       }
     }
+    .path-selection__terms-of-use {
+      padding-top: 8px;
+
+      a {
+        color: $duo-blue-60;
+      }
+    }
   }
 }


### PR DESCRIPTION
Adds Terms of Use to the application. The terms can be read here:

https://watson-developer-cloud.github.io/terms?name=Watson%20Assistant%20Demo

![image](https://user-images.githubusercontent.com/4694018/58036823-007b3d00-7afa-11e9-837a-60a391fca877.png)


